### PR TITLE
Fix attach stocked comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
-## v0.0.1
+## v1.0.1
+
+Fixed a bug where 「Stocked Comments」 is not displayed. (2019/5/27)
+
+## v1.0.0
 
 First Release (2019/03/09)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-stocked-comments",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Chrome extension project with Vue.js",
   "author": "yukihirop <te108186@gmail.com>",
   "license": "MIT",

--- a/src/content/github/components/Header.js
+++ b/src/content/github/components/Header.js
@@ -5,7 +5,7 @@ import LoginUserInfo from '@/apis/github/LoginUserInfo'
 export default class Header {
   constructor () {
     this.$head = $('head')
-    this.$headerUl = $('header nav ul')
+    this.$headerUl = $('header nav')
     this.loginUserName = $('details-menu[role=menu]').find('a:contains("Signed in as")').children().text()
     this.isAfterSignIn = this.checkAfterSignIn()
   }
@@ -40,6 +40,6 @@ export default class Header {
 
   // private
   stockedCommentsLinkLi () {
-    return '<li><a class="js-selected-navigation-item HeaderNavlink px-lg-2 py-2 py-lg-0" href="#Stocked_Comments">&thinsp;Stocked Comments</a></li>'
+    return '<a class="js-selected-navigation-item Header-link mr-3" href="#Stocked_Comments">&thinsp;Stocked Comments</a>'
   }
 }


### PR DESCRIPTION
## 概要

GitHubのヘッダーメニューのcssが変わっていて、「Stocked Comments」が正常に表示されないようになってた。

![image](https://user-images.githubusercontent.com/11146767/58364345-15871000-7eee-11e9-8a2f-5a904da79a07.png)
